### PR TITLE
Include tiny_queue.h in tiny_queue.m

### DIFF
--- a/tiny_queue.c
+++ b/tiny_queue.c
@@ -3,20 +3,7 @@
 #include <pthread.h>
 #include <sys/types.h>
 #include <string.h>
-
-// Struct to hold the queue
-typedef struct tiny_queue_t {
-  struct tiny_linked_list_t* head;
-  struct tiny_linked_list_t* tail;
-  pthread_mutex_t mutex;
-  pthread_cond_t wakeup;
-} tiny_queue_t;
-
-// Linked list that holds the data in the queue
-typedef struct tiny_linked_list_t {
-  void *data;
-  struct tiny_linked_list_t* next;
-} tiny_linked_list_t;
+#include "tiny_queue.h"
 
 // Create a queue, return a pointer to tiny_queue_t
 tiny_queue_t* tiny_queue_create() {

--- a/tiny_queue.h
+++ b/tiny_queue.h
@@ -2,16 +2,16 @@
 #define __TINY_QUEUE__
 
 typedef struct tiny_queue_t {
-  struct tiny_lined_list_t* head;
-  struct tiny_lined_list_t* tail;
+  struct tiny_linked_list_t* head;
+  struct tiny_linked_list_t* tail;
   pthread_mutex_t mutex;
   pthread_cond_t wakeup;
 } tiny_queue_t;
 
-typedef struct tiny_lined_list_t {
+typedef struct tiny_linked_list_t {
   void *data;
-  struct tiny_lined_list_t* next;
-} tiny_lined_list_t;
+  struct tiny_linked_list_t* next;
+} tiny_linked_list_t;
 
 // Create an instance of tiny_queue
 tiny_queue_t* tiny_queue_create();


### PR DESCRIPTION
In order to avoid declaring tiny_queue_t and tiny_linked_list_t twice,
this commit removes the struct typedefs from tiny_queue.m and instead
pulls in the header file tiny_queue.h. It also removes the typedef for
tiny_lined_list_t and it's usage and instead uses tiny_linked_list_t.